### PR TITLE
feat: add test module with rate limiting endpoint & improved e2e tests

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { MetricsMiddleware } from './health/metrics.middleware';
 import { TracingModule } from './tracing/tracing.module';
 import { TracingMiddleware } from './tracing/tracing.middleware';
 import { ChaosModule } from './chaos/chaos.module';
+import { TestModule } from './test/test.module';
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { ChaosModule } from './chaos/chaos.module';
     HealthModule,
     TracingModule,
     ChaosModule,
+    TestModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/test/test.controller.spec.ts
+++ b/src/test/test.controller.spec.ts
@@ -1,0 +1,23 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TestController } from './test.controller';
+
+describe('TestController', () => {
+  let controller: TestController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TestController],
+    }).compile();
+
+    controller = module.get<TestController>(TestController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return a message for rate limit test endpoint', () => {
+    const result = controller.testRateLimit();
+    expect(result).toEqual({ message: 'Rate limit test endpoint' });
+  });
+});

--- a/src/test/test.controller.ts
+++ b/src/test/test.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { Public } from '../auth/decorators/public.decorator';
+
+@ApiTags('test')
+@Controller('test')
+export class TestController {
+  @Get('rate-limit')
+  @Public()
+  @Throttle({ default: { limit: 3, ttl: 10000 } }) // Strict rate limit for testing: 3 requests per 10 seconds
+  @ApiOperation({ summary: 'Test endpoint for rate limiting' })
+  @ApiResponse({ status: 200, description: 'Returns a test message' })
+  @ApiResponse({ status: 429, description: 'Too Many Requests' })
+  testRateLimit(): { message: string } {
+    return { message: 'Rate limit test endpoint' };
+  }
+}

--- a/src/test/test.module.ts
+++ b/src/test/test.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { TestController } from './test.controller';
+
+@Module({
+  controllers: [TestController],
+})
+export class TestModule {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new public API endpoint for testing rate limiting, accessible at `/test/rate-limit`. This endpoint is limited to 3 requests per 10 seconds and is documented in the API docs.
- **Tests**
  - Introduced tests for the new rate limit test endpoint to verify correct rate limiting behavior and response content.
  - Updated end-to-end tests to target the new rate-limited endpoint and validate rate limiting with explicit assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->